### PR TITLE
perfetto/base/task_runner.h: Makes chromium79 build when using EXTERN…

### DIFF
--- a/src/third_party/perfetto/include/perfetto/base/task_runner.h
+++ b/src/third_party/perfetto/include/perfetto/base/task_runner.h
@@ -18,6 +18,7 @@
 #define INCLUDE_PERFETTO_BASE_TASK_RUNNER_H_
 
 #include <functional>
+#include <cstdint>
 
 #include "perfetto/base/export.h"
 


### PR DESCRIPTION
…ALSRC yocto/OE feat

Building chromium79 from an external source [1], due to missing stdint
headers.

[1] https://docs.yoctoproject.org/dev-manual/common-tasks.html#building-software-from-an-external-source

Signed-off-by: Marius Vlad <marius.vlad@collabora.com>